### PR TITLE
Add CNAME to github workflow

### DIFF
--- a/.github/workflows/gh-pages-merge.yml
+++ b/.github/workflows/gh-pages-merge.yml
@@ -13,3 +13,4 @@ jobs:
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           publish_dir: './out'
+          cname: ash.vin


### PR DESCRIPTION
@Ashvin-Ranjan 
You'll probably need to configure the CNAME github pages settings yourself in the repository settings, if you haven't done so already.